### PR TITLE
Fix invalid delay call in Arduino sketch

### DIFF
--- a/Arducam Livestream.ino
+++ b/Arducam Livestream.ino
@@ -277,7 +277,9 @@ void handleHttpClient(WiFiClient &client)
       Serial.println("Capture failed or client disconnected.");
       break;
     }
-    delay(.3);
+    // delay takes milliseconds as an integer. Using a float causes the delay
+    // to truncate to zero. Use a small integer delay instead.
+    delay(30);
   }
   
   // Once we exit the loop, either the client disconnected or error occurred


### PR DESCRIPTION
## Summary
- fix incorrect fractional delay in `Arducam Livestream.ino`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68504e5199b4832c9be3159b730b091d